### PR TITLE
Change description.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 theme: jekyll-theme-cayman
 title: [JuliaRobotics]
-description: [Julia powered robotics]
+description: [Robotics powered by Julia]


### PR DESCRIPTION
It should either be "Julia-powered Robotics" or this, and I slightly prefer this.