### PR TITLE
remove brackets from title and description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-title: [JuliaRobotics]
-description: [Robotics powered by Julia]
+title: "JuliaRobotics"
+description: "Robotics powered by Julia"
 url: "http://www.juliarobotics.org"
 
 # Build settings


### PR DESCRIPTION
These don't show up on the page, but they do show up in weird places like in the browser window title and the site metadata. @tkoolen was there any reason for the brackets to be here? 